### PR TITLE
add participants per room metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ Gauges:
 * bbb_recordings_unpublished - Total number of BigBlueButton recordings unpublished
 * bbb_recordings_deleted - Total number of BigBlueButton recordings deleted
 * bbb_api_up - 1 if BigBlueButton API is responding 0 otherwise
+* bbb_meetings_rooms_participants - Total number of participants per room in all BigBlueButton meetings
+* bbb_meetings_rooms_video_participants - Total number of video participants per room in all BigBlueButton meetings
+* bbb_meetings_rooms_voice_participants - Total number of voice participants per room in all BigBlueButton meetings
 
 Histograms:
 * bbb_api_latency(labels: endpoint, parameters) - BigBlueButton API call latency

--- a/bbb-exporter/collector.py
+++ b/bbb-exporter/collector.py
@@ -28,6 +28,9 @@ class BigBlueButtonCollector:
         meetings, meetings_data_latency = execution_duration(api.get_meetings)()
 
         no_meetings = len(meetings)
+        no_meetings_rooms_participants_list = list(map(lambda meeting: ([meeting["internalMeetingID"]],int(meeting["participantCount"])), meetings))
+        no_meetings_rooms_video_participants_list = list(map(lambda meeting: ([meeting["internalMeetingID"]],int(meeting["videoCount"])), meetings))
+        no_meetings_rooms_voice_participants_list = list(map(lambda meeting: ([meeting["internalMeetingID"]],int(meeting["voiceParticipantCount"])), meetings))
         no_participants = reduce(lambda total, meeting: total + int(meeting['participantCount']), meetings, 0)
         no_listeners = reduce(lambda total, meeting: total + int(meeting['listenerCount']), meetings, 0)
         no_voice_participants = reduce(lambda total, meeting: total + int(meeting['voiceParticipantCount']), meetings, 0)
@@ -42,6 +45,18 @@ class BigBlueButtonCollector:
         bbb_meetings = GaugeMetricFamily('bbb_meetings', "Number of BigBlueButton meetings")
         bbb_meetings.add_metric([], no_meetings)
         yield bbb_meetings
+        
+        bbb_meetings_rooms_participants = GaugeMetricFamily('bbb_meetings_rooms_participants', "Total number of participants per room in all BigBlueButton meetings", labels=['room'])
+        list(map(lambda meeting: bbb_meetings_rooms_participants.add_metric(*meeting), no_meetings_rooms_participants_list))
+        yield bbb_meetings_rooms_participants
+        
+        bbb_meetings_rooms_video_participants = GaugeMetricFamily('bbb_meetings_rooms_video_participants', "Total number of video participants per room in all BigBlueButton meetings", labels=['room'])
+        list(map(lambda meeting: bbb_meetings_rooms_video_participants.add_metric(*meeting), no_meetings_rooms_video_participants_list))
+        yield bbb_meetings_rooms_video_participants
+
+        bbb_meetings_rooms_voice_participants = GaugeMetricFamily('bbb_meetings_rooms_voice_participants', "Total number of voice participants per room in all BigBlueButton meetings", labels=['room'])
+        list(map(lambda meeting: bbb_meetings_rooms_voice_participants.add_metric(*meeting), no_meetings_rooms_voice_participants_list))
+        yield bbb_meetings_rooms_voice_participants
 
         bbb_meetings_participants = GaugeMetricFamily('bbb_meetings_participants',
                                                       "Total number of participants in all BigBlueButton meetings")


### PR DESCRIPTION
This change adds three new metrics:

* `bbb_meetings_rooms_participants` - Total number of participants per room in all BigBlueButton meetings
* `bbb_meetings_rooms_video_participants` - Total number of video participants per room in all BigBlueButton meetings
* `bbb_meetings_rooms_voice_participants` - Total number of voice participants per room in all BigBlueButton meetings

Example output:

```
# HELP bbb_meetings_rooms_participants Total number of participants per room in all BigBlueButton meetings
# TYPE bbb_meetings_rooms_participants gauge
bbb_meetings_rooms_participants{room="3675cc22c0a54fa5ba93ef068d03589a9a706b4d-1586473606666"} 1.0
bbb_meetings_rooms_participants{room="8304aa9021e6fc07a736e31db0429a7d2fa1134d-1586473549597"} 2.0
# HELP bbb_meetings_rooms_video_participants Total number of video participants per room in all BigBlueButton meetings
# TYPE bbb_meetings_rooms_video_participants gauge
bbb_meetings_rooms_video_participants{room="3675cc22c0a54fa5ba93ef068d03589a9a706b4d-1586473606666"} 0.0
bbb_meetings_rooms_video_participants{room="8304aa9021e6fc07a736e31db0429a7d2fa1134d-1586473549597"} 0.0
# HELP bbb_meetings_rooms_voice_participants Total number of voice participants per room in all BigBlueButton meetings
# TYPE bbb_meetings_rooms_voice_participants gauge
bbb_meetings_rooms_voice_participants{room="3675cc22c0a54fa5ba93ef068d03589a9a706b4d-1586473606666"} 0.0
bbb_meetings_rooms_voice_participants{room="8304aa9021e6fc07a736e31db0429a7d2fa1134d-1586473549597"} 1.0
```
#9 
