### PR TITLE
New metric: number of participants by client

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Gauges:
 * bbb_meetings_listeners - Total number of listeners in all BigBlueButton meetings
 * bbb_meetings_voice_participants - Total number of voice participants in all BigBlueButton meetings
 * bbb_meetings_video_participants - Total number of video participants in all BigBlueButton meetings
+* bbb_meetings_participant_clients - Total number of participants in all BigBlueButton meetings by client
 * bbb_recordings_processing - Total number of BigBlueButton recordings processing
 * bbb_recordings_processed - Total number of BigBlueButton recordings processed
 * bbb_recordings_published - Total number of BigBlueButton recordings published

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Gauges:
 * bbb_meetings_listeners - Total number of listeners in all BigBlueButton meetings
 * bbb_meetings_voice_participants - Total number of voice participants in all BigBlueButton meetings
 * bbb_meetings_video_participants - Total number of video participants in all BigBlueButton meetings
-* bbb_meetings_participant_clients(labels: client) - Total number of participants in all BigBlueButton meetings by client (html5|dial-in|flash)
+* bbb_meetings_participant_clients(type=<client>) - Total number of participants in all BigBlueButton meetings by client (html5|dial-in|flash)
 * bbb_recordings_processing - Total number of BigBlueButton recordings processing
 * bbb_recordings_processed - Total number of BigBlueButton recordings processed
 * bbb_recordings_published - Total number of BigBlueButton recordings published

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Gauges:
 * bbb_meetings_listeners - Total number of listeners in all BigBlueButton meetings
 * bbb_meetings_voice_participants - Total number of voice participants in all BigBlueButton meetings
 * bbb_meetings_video_participants - Total number of video participants in all BigBlueButton meetings
-* bbb_meetings_participant_clients - Total number of participants in all BigBlueButton meetings by client
+* bbb_meetings_participant_clients(labels: client) - Total number of participants in all BigBlueButton meetings by client (html5|dial-in|flash)
 * bbb_recordings_processing - Total number of BigBlueButton recordings processing
 * bbb_recordings_processed - Total number of BigBlueButton recordings processed
 * bbb_recordings_published - Total number of BigBlueButton recordings published

--- a/bbb-exporter/collector.py
+++ b/bbb-exporter/collector.py
@@ -140,9 +140,11 @@ class BigBlueButtonCollector:
         logging.info("Finished collecting metrics from BigBlueButton API")
 
     @staticmethod
-    def _get_participant_count_by_client(self, meetings):
+    def _get_participant_count_by_client(meetings):
         p_by_c = defaultdict(int, {'HTML5': 0, 'DIAL-IN': 0, 'FLASH': 0})
         for meeting in meetings:
+            if not meeting.get("attendees"):
+                continue
             if isinstance(meeting['attendees']['attendee'], list):
                 attendees = meeting['attendees']['attendee']
             else:


### PR DESCRIPTION
This metric is interesting if some of your users use the FLASH client and even more if they use dial in. I personally use it to monitor if the number of available phone lines is enough via prometheus.

I find the code to calculate the number per client a bit ugly, especially compared to your code, so if you have a nicer way of writing that, I'm all ears.

I used the `defaultdict` because from my understanding of the code the `clientType` is set by the client and could be set to something else than the three values used by the official bigbluebutton clients.