### PR TITLE
refresh instance list

### DIFF
--- a/extras/grafana_dashboard_server_instance.json
+++ b/extras/grafana_dashboard_server_instance.json
@@ -972,7 +972,7 @@
         "name": "instance",
         "options": [],
         "query": "label_values(bbb_api_up, instance)",
-        "refresh": 0,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,


### PR DESCRIPTION
Maybe I did sth wrong but in my case no instances (as presented in the yml file) was shown. The field was empty (though I could enter the instances manually (`hostname:port`). Even then the `netdata`-data (cpu utilization, ...) did not show up though I could retrieve them manually via the netdata-page.

When changing the variable refresh to `on dashboard load` everything worked!

I am not 100% sure if this change in the provided json will solve the problem - but this is how the updated dashboard json looks like in my case.