### PR TITLE
Special Consideration if using Grafana - bigbluebutton-exporter.md

### DIFF
--- a/docs/installation/all_in_one_monitoring_stack.md
+++ b/docs/installation/all_in_one_monitoring_stack.md
@@ -50,7 +50,7 @@ Get your BBB secret by running:
 bbb-conf --secret
 ```
 
-Then fill out `API_BASE_URL` and `API_SECRET` in `~/bbb-monitoring/secrets.env` with your details.
+Then fill out `API_BASE_URL` and `API_SECRET` in `~/bbb-monitoring/bbb_exporter_secrets.env` with your details.
 
 !!! warning
     The API base url ends with `/api/` (beware of the trailing slash!). `bbb-conf --secret` will return the base url but
@@ -92,10 +92,10 @@ location /monitoring/ {
 !!! Tip
     When upgrading BigBlueButton, the upgrade procedure will overwrite the contents of `/etc/nginx/sites-available/bigbluebutton`
     thereby causing you to lose access to your metrics. 
-    So after the upgrade od BigBlueButton you will need to add the location directive again.
+    So after the upgrade to BigBlueButton you will need to add the location directive again.
     
-    You could also add a seperate site configuration, but this will require you do point another domain to the server to
-    do virtual hosting and acquire a seperate HTTPS certificate.
+    You could also add a separate site configuration, but this will require you to point another domain to the server to
+    do virtual hosting and acquire a separate HTTPS certificate.
 
 ### 6. Setup Grafana
 Login to Grafana (https://example.com/monitoring) in your web browser (admin:admin) and **change the password**.


### PR DESCRIPTION
Grafana HTTP by default uses port 3000 as does APP HTML5 so this will break your HTML5 on your BBB instance. Suggest changing Grafana's HTTP port to 3030 or another open port of your choosing, by modifying grafana.ini or default.ini

i.e.
```
/usr/share/grafana/conf/defaults.ini
```
```
# The http port to use
http_port = 3030
```