### PR TITLE
switch to alpine-based python image for reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-stretch
+FROM python:3.8-alpine
 EXPOSE 9688
 
 COPY requirements.txt /app/requirements.txt


### PR DESCRIPTION
this PR changes the base image to `python:3.8-alpine` which reduces the resulting image by 880MB.

resulting image sizes by base image:
```
 951MB python:3.7-stretch
  90MB python:3.8-alpine
```