### PR TITLE
Panel Recordings Unprocessed - name correction

### DIFF
--- a/docs/installation/all_in_one_monitoring_stack.md
+++ b/docs/installation/all_in_one_monitoring_stack.md
@@ -71,8 +71,7 @@ sudo docker-compose up -d
 ```
 
 ### 5. Configure Nginx
-Add the location directive to your Nginx web server (`/etc/nginx/sites-available/bigbluebutton`) that will proxy traffic to
-`127.0.0.1:3001`.
+Add the location directive monitoring.nginx to your Nginx web server (`/etc/bigbluebutton/nginx/monitoring.nginx` - config from this location will be loaded automatically by nginx BigBlueButton config) that will proxy traffic to `127.0.0.1:3001`.
 
 ```text
 # BigBlueButton monitoring
@@ -98,9 +97,7 @@ location /monitoring/ {
     variable as well.
 
 !!! Tip
-    When upgrading BigBlueButton, the upgrade procedure will overwrite the contents of `/etc/nginx/sites-available/bigbluebutton`
-    thereby causing you to lose access to your metrics. 
-    So after the upgrade to BigBlueButton you will need to add the location directive again.
+    When upgrading BigBlueButton, the upgrade procedure will not overwrite the contents of `/etc/bigbluebutton/nginx/`folder. 
     
     You could also add a separate site configuration, but this will require you to point another domain to the server to
     do virtual hosting and acquire a separate HTTPS certificate.

--- a/docs/installation/bigbluebutton_exporter.md
+++ b/docs/installation/bigbluebutton_exporter.md
@@ -89,8 +89,8 @@ sudo htpasswd -c /etc/nginx/.htpasswd metrics
     If you already have `/etc/nginx/.htpasswd` file then do not add the `-c` flag, otherwise you will overwrite the file.
 
 ### 6. Add Nginx site configuration
-Add the location directive to your Nginx web server (`/etc/nginx/sites-available/bigbluebutton`) that will proxy traffic to
-`127.0.0.1:9688`.
+Add the location directive to your Nginx web server (`/etc/bigbluebutton/nginx/metrics.nginx` - BigBlueButton Nginx config will load config from location `/etc/bigbluebutton/nginx/*.nginx`) that will proxy traffic to
+`127.0.0.1:9688`. 
 
 ```text
 # BigBlueButton Exporter (metrics)
@@ -104,10 +104,6 @@ location /metrics/ {
 ```
 
 !!! Tip
-    When upgrading BigBlueButton (using the script), the upgrade procedure will overwrite the contents of `/etc/nginx/sites-available/bigbluebutton`
-    thereby causing you to lose access to your metrics. 
-    So after the upgrade you will need to add the location directive again.
-    
     You could also add a separate site configuration, but this will require you to point another domain to the server,
     configure virtual hosting and acquire a separate HTTPS certificate.
 

--- a/extras/dashboards/all_servers.json
+++ b/extras/dashboards/all_servers.json
@@ -1203,7 +1203,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Recordings Processing",
+      "title": "Recordings Unprocessed",
       "type": "gauge"
     },
     {


### PR DESCRIPTION
2 dashes with "Recordings Processing" name were available. It renames second to correct name.