### PR TITLE
Add metric to show participants by origin servername

### DIFF
--- a/bbb-exporter/collector.py
+++ b/bbb-exporter/collector.py
@@ -303,7 +303,7 @@ class BigBlueButtonCollector:
             if participants == 0:
                 continue
             if not meeting.get("metadata") or not meeting['metadata'].get(metadata_key):
-                p_by_m['_no_metadata'] += participants
+                p_by_m[''] += participants
             else:
                 p_by_m[meeting['metadata'][metadata_key]] += participants
 

--- a/bbb-exporter/collector.py
+++ b/bbb-exporter/collector.py
@@ -68,7 +68,7 @@ class BigBlueButtonCollector:
         yield self.metric_meetings_video_participants(meetings)
 
         yield self.metric_meetings_participant_clients(meetings)
-        yield self.metric_meetings_participant_origin(meetings)
+        yield self.metric_meetings_participants_origin(meetings)
 
         if settings.RECORDINGS_METRICS_ENABLE:
             yield self.metric_recordings_unpublished(bbb_api_latency)
@@ -129,9 +129,9 @@ class BigBlueButtonCollector:
         metric.add_metric([], no_listeners)
         return metric
     
-    def metric_meetings_participant_origin(self, meetings):
-        participants_by_origin = self._get_participant_count_by_origin(meetings)
-        metric = GaugeMetricFamily('bbb_meetings_participant_origin',
+    def metric_meetings_participants_origin(self, meetings):
+        participants_by_origin = self._get_participants_count_by_origin(meetings)
+        metric = GaugeMetricFamily('bbb_meetings_participants_origin',
                                    "Total number of participants in all BigBlueButton meetings by origin servername",
                                    labels=["server", "name"])
         for (servername, origin), num in participants_by_origin.items():
@@ -295,7 +295,7 @@ class BigBlueButtonCollector:
         return p_by_c
 
     @staticmethod
-    def _get_participant_count_by_origin(meetings):
+    def _get_participants_count_by_origin(meetings):
         p_by_m = defaultdict(int)
         for meeting in meetings:
             participants = int(meeting['participantCount'])

--- a/docs/exporter-user-guide.md
+++ b/docs/exporter-user-guide.md
@@ -75,7 +75,7 @@ metric
 * bbb_meetings_voice_participants - Total number of voice participants in all BigBlueButton meetings
 * bbb_meetings_video_participants - Total number of video participants in all BigBlueButton meetings
 * bbb_meetings_participant_clients(type=<client\>) - Total number of participants in all BigBlueButton meetings by client (html5|dial-in|flash)
-* bbb_meetings_participant_origin_servername(origin=<servername\>) - Total number of participants in all BigBlueButton meetings by servername (e.g. when using multiple greenlight instances with a single big blue button server, or adding custom bbb-origin-server-name metadata tags in your application using BigBlueButton)
+* bbb_meetings_participant_origin(server=<servername\>, name=<origin>) - Total number of participants in all BigBlueButton meetings by servername and origin metadata (e.g. when using multiple greenlight instances with a single big blue button server, or adding custom bbb-origin-server-name or bbb-origin metadata tags in your application using BigBlueButton)
 * bbb_recordings_processing - Total number of BigBlueButton recordings processing
 * bbb_recordings_published - Total number of BigBlueButton recordings published
 * bbb_recordings_unpublished - Total number of BigBlueButton recordings unpublished

--- a/docs/exporter-user-guide.md
+++ b/docs/exporter-user-guide.md
@@ -75,6 +75,7 @@ metric
 * bbb_meetings_voice_participants - Total number of voice participants in all BigBlueButton meetings
 * bbb_meetings_video_participants - Total number of video participants in all BigBlueButton meetings
 * bbb_meetings_participant_clients(type=<client\>) - Total number of participants in all BigBlueButton meetings by client (html5|dial-in|flash)
+* bbb_meetings_participant_origin_servername(origin=<servername\>) - Total number of participants in all BigBlueButton meetings by servername (e.g. when using multiple greenlight instances with a single big blue button server, or adding custom bbb-origin-server-name metadata tags in your application using BigBlueButton)
 * bbb_recordings_processing - Total number of BigBlueButton recordings processing
 * bbb_recordings_published - Total number of BigBlueButton recordings published
 * bbb_recordings_unpublished - Total number of BigBlueButton recordings unpublished


### PR DESCRIPTION
Greenlight sets a metadata field called `bbb-origin-server-name` with the server name of the greenlight instance.

I administrate a BBB server which has two greenlights and a custom application as users. I would like to see an approximate distribution of where clients are coming from.

This adds this metric as `bbb_meetings_participant_origin_servername` with the servername in the `origin` field. Meetings with participants without the metadata field set get added to a `_no_metadata` group:

`bbb_meetings_participant_origin_servername{origin="_no_metadata"}`