### PR TITLE
Optional docker extra_hosts option

### DIFF
--- a/extras/docker-compose.exporter.yaml
+++ b/extras/docker-compose.exporter.yaml
@@ -9,6 +9,10 @@ services:
       # Can be removed if `RECORDINGS_METRICS_READ_FROM_DISK` is set to false (or omitted).
       # See https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations for details.
       - "/var/bigbluebutton:/var/bigbluebutton:ro"
+    # There can be an issue of DNS resolution if the hostname and the api url is the same. 
+    # Docker then advertises the FQDN as a local 127.0.0.1 IP inside the container.
+    #extra_hosts: 
+    #  - 'host-fqdn:PUBLIC.HOST.IP.ADDRESS'
     environment:
       RECORDINGS_METRICS_READ_FROM_DISK: "true"
     env_file:


### PR DESCRIPTION
If the docker hostname and the api FQDN match, docker creates a hosts file in the container where the FQDN resolves to a local IP. To access the BBB API on the host, just add an extra host in the docker config.