### PR TITLE
Fixed unit of Network in all server dashboard

### DIFF
--- a/extras/dashboards/all_servers.json
+++ b/extras/dashboards/all_servers.json
@@ -1373,7 +1373,7 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
+          "format": "bps",
           "label": null,
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
At least for the node_exporter expressions, they output a bits/s value which is wrongly displayed as bytes. The correct unit is bits/s
I have not tested the output of netdata but it will definitely output a rate and IMHO for networks bits/s is the most useful unit.