### PR TITLE
fix no recordings in BBB 2.6

### DIFF
--- a/bbb-exporter/api.py
+++ b/bbb-exporter/api.py
@@ -43,6 +43,9 @@ def get_recordings(state: str):
     if data is None:
         return []
 
+    if data['response']['messageKey'] == 'noRecordings':
+        return []
+
     if data['response']['recordings'] is None:
         return []
 


### PR DESCRIPTION
Since BBB 2.6, when you don't have any recording, the BBB API return a message key with 'noRecordings'. This PR handle this message and return an empty array.