### PR TITLE
make BBB version available as metric

### DIFF
--- a/bbb-exporter/collector.py
+++ b/bbb-exporter/collector.py
@@ -107,6 +107,13 @@ class BigBlueButtonCollector:
         bbb_exporter.add_metric([settings.VERSION], 1)
         yield bbb_exporter
 
+        # read BBB version from disk
+        with open("/etc/bigbluebutton/bigbluebutton-release", "r") as f:
+            bbb_release = f.read()
+        bbb_version = GaugeMetricFamily("bbb_version", "BigBlueButton version", labels=["version"])
+        bbb_version.add_metric([bbb_release.strip().split("=")[1]], 1)
+        yield bbb_version
+
         logging.info("Finished collecting metrics from BigBlueButton API")
 
     def metric_meetings(self, meetings):

--- a/extras/docker-compose.exporter.yaml
+++ b/extras/docker-compose.exporter.yaml
@@ -6,6 +6,7 @@ services:
     ports:
       - "127.0.0.1:9688:9688"
     volumes:
+      - "/etc/bigbluebutton/bigbluebutton-release:/etc/bigbluebutton/bigbluebutton-release:ro"
       # Can be removed if `RECORDINGS_METRICS_READ_FROM_DISK` is set to false (or omitted).
       # See https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations for details.
       - "/var/bigbluebutton:/var/bigbluebutton:ro"


### PR DESCRIPTION
For larger clusters it can be nice to have the BBB version available as a metric. This patch adds that functionality.

The version than appears as a label, similar to the exporter version metric:

```
# HELP bbb_version BigBlueButton version
# TYPE bbb_version gauge
bbb_version{version="2.7.2"} 1.0
```