### PR TITLE
Fix #128

### DIFF
--- a/bbb-exporter/api.py
+++ b/bbb-exporter/api.py
@@ -29,7 +29,7 @@ def get_meetings():
     response = []
 
     for meeting in meetings:
-        if type(meeting) != OrderedDict:
+        if not isinstance(meeting, dict):
             continue
 
         response.append(meeting)
@@ -66,7 +66,7 @@ def get_recordings(state: str):
     response = []
 
     for recording in recordings:
-        if type(recording) != OrderedDict:
+        if not isinstance(recording, dict):
             continue
 
         response.append(recording)


### PR DESCRIPTION
Upgrading xmltodict from 0.12 to 0.13 dropped OrderedDict support and broke filtering for this type. This closes #128.